### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
The doc/tags is autocreated by vim and shows itself as untracked content when using git submodules for .vim plugin management.